### PR TITLE
Add node_modules and dist to ignored folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,9 +23,13 @@ $RECYCLE.BIN/
 # ## General
 # Build folders should never be comitted
 build/
+dist/
 
 # Local configuration file (sdk path, etc)
 local.properties
 
 # Log Files
 *.log
+
+# Dependency directory
+node_modules/


### PR DESCRIPTION
I use npm for almost all of my web projects and it´s not a great idea to have the `node_modules` folder to be apart of the repo.

I sometimes use both a `dist` and a `build` folder in my projects. `build` for for bundling JS files, compiling SCSS files etc. and `dist` for the "final" build when everything is concatenated and minified.
